### PR TITLE
Fix email input discrepancies

### DIFF
--- a/middlewares/UserMiddleware.js
+++ b/middlewares/UserMiddleware.js
@@ -54,7 +54,7 @@ const validateNewUser = (req, res, next) => {
 
   // Sanitize inputs
   req.body.username = validator.escape(username);
-  req.body.email = validator.normalizeEmail(email);
+  req.body.email = validator.escape(email);
   req.body.password = validator.escape(password);
 
   next();


### PR DESCRIPTION


**Issue:**  
During user registration, the `validateNewUser` middleware was normalizing email addresses, causing discrepancies between the email entered by the user and the one stored with the registration token. For example, `jncp.wu@gmail.com` was being normalized to `jncpwu@gmail.com`, leading to a mismatch and failed registration.

**Fix:**  
- Updated the `validateNewUser` middleware to prevent normalization of the email field.  
- Switched from using `validator.normalizeEmail` to `validator.escape`, ensuring that the input is still sanitized while retaining the original format of the email address.
- This approach prevents potential security issues, such as script injection attacks, while maintaining the integrity of the email format for validation against the registration token.
