### PR TITLE
Add HR login endpoint

### DIFF
--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -9,15 +9,21 @@ const {
   postRegisterUser,
   validateRegistrationToken,
 } = require('../controllers/authController');
-const { postLoginUser } = require('../controllers/loginController');
+const {
+  postLoginUser,
+  postLoginHR,
+} = require('../controllers/loginController');
 
 const authRouter = Router();
 
 // Route to handle employee/HR registration
 authRouter.post('/register', validateNewUser, postRegisterUser);
 
-// Route to handle employee/HR login
+// Route to handle employee/HR login to React app
 authRouter.post('/login', validateLoginUser, postLoginUser);
+
+// Route to handle only HR login to Angular app
+authRouter.post('/HRlogin', validateLoginUser, postLoginHR);
 
 // Route to validate registration token before displaying the registration form
 authRouter.get('/validate-token', validateRegistrationToken);


### PR DESCRIPTION


### Summary of Changes:

1. **New HR Login Endpoint:**
   - Created a separate controller function `postLoginHR` specifically for handling HR logins.
   - The new HR login route `/api/auth/HRlogin` was added to ensure that only users with the "HR" role can log in to the HR site.

2. **Controller Logic:**
   - The `postLoginHR` controller validates the user's credentials.
   - It checks that the user's role is "HR" before allowing access.
   - If the credentials are valid and the role is correct, a JWT token is generated and returned to the client.
   - If the user's role is not "HR" or the credentials are incorrect, the controller returns a `401 Unauthorized` response with an appropriate error message.

3. **Security Considerations:**
   - JWT tokens generated for HR users include the user's ID, username, and role, ensuring secure authentication and authorization.
   - The token is set to expire in 1 hour, following best practices for security.

### Testing & Validation:

- Tested the new HR login endpoint with valid and invalid credentials to ensure proper behavior.
- Verified that only users with the "HR" role can log in through the new endpoint, while employees receive a `401 Unauthorized` response.

### Notes:

- The existing employee login endpoint `/api/auth/login` remains unchanged, and it continues to allow only "Employee" role users to log in.
